### PR TITLE
Allow app.py to be run directly

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,20 @@ import altair as alt
 
 from stitcher import stitch_terms
 
+# If this script is executed with `python app.py` instead of
+# `streamlit run app.py`, re-launch it via the Streamlit CLI so the
+# interactive app works as expected.
+try:  # pragma: no cover - best effort safeguard
+    from streamlit.runtime.scriptrunner_utils import script_run_context
+    if script_run_context.get_script_run_ctx() is None:  # not running via `streamlit run`
+        import sys
+        from streamlit.web import cli as stcli
+
+        sys.argv = ["streamlit", "run", sys.argv[0]]
+        sys.exit(stcli.main())
+except Exception:
+    pass
+
 st.set_page_config(page_title="Trends Stitcher", layout="wide")
 st.title("Google Trends: Auto-Stitched Comparable Scale")
 


### PR DESCRIPTION
## Summary
- Add bootstrap code so running `python app.py` relaunches through `streamlit run`, making it easier to start the app.

## Testing
- `python -m py_compile app.py stitcher.py`
- `python app.py`
- `streamlit run app.py --server.headless true`


------
https://chatgpt.com/codex/tasks/task_e_68aad1586420832d871f820c5f670feb