### PR TITLE
Handle duplicates in pairwise_ratios

### DIFF
--- a/stitcher.py
+++ b/stitcher.py
@@ -208,7 +208,7 @@ def pairwise_ratios(df_long: pd.DataFrame) -> pd.DataFrame:
     out = []
     for (bid, date), g in df_long.groupby(["batch_id", "date"], sort=False):
         # single-date wide
-        w = g.pivot(index="date", columns="term", values="value")
+        w = g.pivot_table(index="date", columns="term", values="value", aggfunc="mean")
         if w.empty:
             continue
         terms = list(w.columns)

--- a/tests/test_pairwise_ratios.py
+++ b/tests/test_pairwise_ratios.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import pandas as pd
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from stitcher import pairwise_ratios
+
+
+def test_pairwise_ratios_handles_duplicates():
+    data = [
+        {"batch_id": "b1", "date": "2024-01-01", "term": "alpha", "value": 10},
+        {"batch_id": "b1", "date": "2024-01-01", "term": "alpha", "value": 20},
+        {"batch_id": "b1", "date": "2024-01-01", "term": "beta", "value": 30},
+    ]
+    df = pd.DataFrame(data)
+    result = pairwise_ratios(df)
+
+    ratio_ab = result[(result.term_i == "alpha") & (result.term_j == "beta")]["ratio_med"].iloc[0]
+    ratio_ba = result[(result.term_i == "beta") & (result.term_j == "alpha")]["ratio_med"].iloc[0]
+
+    assert ratio_ab == 0.5
+    assert ratio_ba == 2.0


### PR DESCRIPTION
## Summary
- Use `pivot_table` with mean aggregation in `pairwise_ratios` to tolerate duplicate term rows
- Add regression test to ensure duplicate `(batch_id, date, term)` rows no longer raise errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aad397d264832d8c644a760ab42023