### PR TITLE
Add SerpAPI debug logging and optional caching

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,6 +46,8 @@ with st.sidebar:
     st.subheader("Advanced")
     cache_dir = st.text_input("Cache directory", value=".cache")
     sleep_ms = st.number_input("Request sleep (ms)", min_value=0, value=250)
+    use_cache = st.checkbox("Use cache", value=True)
+    show_debug = st.checkbox("Show debug logs", value=False)
 
     run = st.button("Run")
 
@@ -157,6 +159,8 @@ if run:
             group_size=group_size,
             cache_dir=cache_dir,
             sleep_ms=int(sleep_ms),
+            use_cache=use_cache,
+            debug=show_debug,
         )
 
         df_scaled = filter_date_range(df_scaled, start_date, end_date)


### PR DESCRIPTION
## Summary
- Expose cache and debug toggles in Streamlit UI
- Log request/response details and SerpAPI errors in `TrendsFetcher`
- Test `_parse_timeseries` for nested, flat and missing payload structures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aad8816cbc832d891455b8289a2417