### PR TITLE
Add cache flag tests and verbose toggle

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,6 +48,7 @@ with st.sidebar:
     sleep_ms = st.number_input("Request sleep (ms)", min_value=0, value=250)
     use_cache = st.checkbox("Use cache", value=True)
     show_debug = st.checkbox("Show debug logs", value=False)
+    verbose_logs = st.checkbox("Verbose logging", value=False)
 
     run = st.button("Run")
 
@@ -159,6 +160,7 @@ if run:
             group_size=group_size,
             cache_dir=cache_dir,
             sleep_ms=int(sleep_ms),
+            verbose=verbose_logs,
             use_cache=use_cache,
             debug=show_debug,
         )

--- a/tests/test_use_cache.py
+++ b/tests/test_use_cache.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from stitcher import stitch_terms
+
+
+class DummyResponse:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status_code = 200
+        self.headers = {}
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        pass
+
+
+PAYLOAD = {
+    "interest_over_time": {
+        "timeline_data": [
+            {"time": "2024-01-01", "value": [1, 2]},
+            {"time": "2024-01-02", "value": [3, 4]},
+        ]
+    }
+}
+
+
+def setup_mocks(monkeypatch, calls):
+    monkeypatch.setattr(
+        "stitcher.requests.get", lambda *args, **kwargs: DummyResponse(PAYLOAD)
+    )
+    monkeypatch.setattr("stitcher.os.makedirs", lambda *a, **k: None)
+
+    def fake_load_cache(path):
+        calls["load"] += 1
+        return None
+
+    def fake_save_cache(path, data):
+        calls["save"] += 1
+
+    monkeypatch.setattr("stitcher._load_cache", fake_load_cache)
+    monkeypatch.setattr("stitcher._save_cache", fake_save_cache)
+
+
+def test_use_cache_true_invokes_cache(monkeypatch):
+    calls = {"load": 0, "save": 0}
+    setup_mocks(monkeypatch, calls)
+    stitch_terms(
+        serpapi_key="dummy",
+        terms=["nike", "adidas"],
+        use_cache=True,
+        verbose=False,
+        sleep_ms=0,
+    )
+    assert calls["load"] == 1
+    assert calls["save"] == 1
+
+
+def test_use_cache_false_bypasses_cache(monkeypatch):
+    calls = {"load": 0, "save": 0}
+    setup_mocks(monkeypatch, calls)
+    stitch_terms(
+        serpapi_key="dummy",
+        terms=["nike", "adidas"],
+        use_cache=False,
+        verbose=False,
+        sleep_ms=0,
+    )
+    assert calls["load"] == 0
+    assert calls["save"] == 0


### PR DESCRIPTION
## Summary
- Add "Verbose logging" sidebar option and disable logs by default
- Add regression tests ensuring cache load/save occur only when use_cache=True

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab0b5f9a30832d9a5723afa8ca669a