### PR TITLE
Warn when pairwise ratios are empty

### DIFF
--- a/stitcher.py
+++ b/stitcher.py
@@ -401,7 +401,15 @@ def stitch_terms(
     if verbose:
         print("[stitch_terms] Computing pairwise ratios")
     pw = pairwise_ratios(df_long)
-    if verbose:
+    if pw.empty:
+        msg = "No overlapping data found; default scale of 1 used."
+        try:  # pragma: no cover - streamlit optional
+            import streamlit as st
+
+            st.warning(msg)
+        except Exception:
+            print(f"[stitch_terms] {msg}")
+    elif verbose:
         print(f"[stitch_terms] {len(pw)} pairwise ratios computed")
     if verbose:
         print("[stitch_terms] Computing consensus scale")

--- a/tests/test_stitch_terms_warning.py
+++ b/tests/test_stitch_terms_warning.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import sys
+from types import ModuleType
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from stitcher import TrendsFetcher, stitch_terms
+
+
+def test_stitch_terms_warns_on_empty_pairwise(monkeypatch):
+    # Stub out streamlit to capture warnings
+    record = {}
+    stub = ModuleType("streamlit")
+
+    def warning(msg):
+        record["msg"] = msg
+
+    stub.warning = warning
+    monkeypatch.setitem(sys.modules, "streamlit", stub)
+
+    # Return all-zero values so pairwise_ratios is empty
+    def fake_fetch_batch(self, batch):
+        rows = [
+            {"date": "2024-01-01", "term": t, "value": 0}
+            for t in batch
+        ]
+        return pd.DataFrame(rows)
+
+    monkeypatch.setattr(TrendsFetcher, "fetch_batch", fake_fetch_batch)
+
+    _, _, scales = stitch_terms(
+        "dummy", ["alpha", "beta"], verbose=False, use_cache=False
+    )
+
+    assert record["msg"] == "No overlapping data found; default scale of 1 used."
+    assert scales.to_dict() == {"alpha": 1.0, "beta": 1.0}
+


### PR DESCRIPTION
## Summary
- Warn when no overlapping data produces empty pairwise ratios and default to scale 1
- Test stitch_terms for warning path using zero-valued payloads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab198b02dc832d84cd983f1fbd4f59