### PR TITLE
chore: remove python-dotenv dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ pandas>=2.2.2
 numpy>=1.26.4
 requests>=2.32.3
 altair>=5.3.0
-python-dotenv>=1.0.1


### PR DESCRIPTION
## Summary
- remove `python-dotenv` requirement

## Testing
- `python app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab74bb40f4832d84ce7f51a1e72c9e