### PR TITLE
Handle cache directory creation failures

### DIFF
--- a/stitcher.py
+++ b/stitcher.py
@@ -17,7 +17,12 @@ import requests
 # -----------------------
 
 def _mk_cache_path(cache_dir: str, params: Dict) -> str:
-    os.makedirs(cache_dir, exist_ok=True)
+    try:
+        os.makedirs(cache_dir, exist_ok=True)
+    except OSError as e:
+        raise RuntimeError(
+            f"Failed to create cache directory '{cache_dir}': {e}"
+        ) from e
     blob = json.dumps(params, sort_keys=True, ensure_ascii=False)
     h = hashlib.sha256(blob.encode("utf-8")).hexdigest()[:24]
     return os.path.join(cache_dir, f"{h}.json")

--- a/tests/test_use_cache.py
+++ b/tests/test_use_cache.py
@@ -5,7 +5,7 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from stitcher import stitch_terms
+from stitcher import stitch_terms, _mk_cache_path
 
 
 class DummyResponse:
@@ -74,3 +74,12 @@ def test_use_cache_false_bypasses_cache(monkeypatch):
     )
     assert calls["load"] == 0
     assert calls["save"] == 0
+
+
+def test_cache_dir_creation_failure(monkeypatch):
+    def fail(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("stitcher.os.makedirs", fail)
+    with pytest.raises(RuntimeError, match="Failed to create cache directory"):
+        _mk_cache_path("tmp", {})


### PR DESCRIPTION
## Summary
- ensure cache directory creation errors raise clear RuntimeError
- test cache directory creation failure handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab74cca150832d91b148062ddee26c