### PR TITLE
Handle dataforseo ai timeline data error

### DIFF
--- a/stitcher.py
+++ b/stitcher.py
@@ -149,7 +149,7 @@ class TrendsFetcher:
                         "keywords": terms,
                         "language_code": "en",
                         **({"country_iso_code": self.geo} if self.geo else {}),
-                        "time_range": self._map_timeframe_to_dfs_range(self.timeframe),
+                        "timeframe": (self.timeframe if self.timeframe else "all"),
                     }]
                     r = requests.post(
                         "https://api.dataforseo.com/v3/keywords_data/google_trends/explore/live",


### PR DESCRIPTION
Fix `Invalid Field: 'time_range'` error by replacing `time_range` with `timeframe` in the DataForSEO Google Trends API payload.

---
<a href="https://cursor.com/background-agent?bcId=bc-84a7672e-a549-402d-8993-d3e63ce937d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-84a7672e-a549-402d-8993-d3e63ce937d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

