### PR TITLE
Ensure TrendsFetcher always exposes a _log_debug callable

### DIFF
--- a/stitcher.py
+++ b/stitcher.py
@@ -117,6 +117,11 @@ class TrendsFetcher:
         self.collect_raw_responses = collect_raw_responses
         self.brightdata_zone = brightdata_zone  # Add this line
         self.raw_responses = []  # Store raw responses for download
+        self._log_debug = (
+            getattr(self, "_log_debug", logger.debug)
+            if debug
+            else (lambda *args, **kwargs: None)
+        )
 
     def fetch_batch(self, terms: List[str]) -> pd.DataFrame:
         if len(terms) > 5:


### PR DESCRIPTION
## Summary
- Ensure `TrendsFetcher` always has a `_log_debug` callable, falling back to a no-op when debugging is disabled

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c715f6eeec832da1c211a2d06e2152