### PR TITLE
Fix DataForSEO yearly parsing for YoY trends

### DIFF
--- a/app.py
+++ b/app.py
@@ -523,7 +523,7 @@ def yoy_table(long_df: pd.DataFrame, term: str) -> pd.DataFrame:
         logger.debug(f"Using tolerance-based matching with {tolerance_days} day tolerance")
         
         # Create a more robust previous year lookup with tolerance
-        g["prev_year_date"] = g["date"].apply(lambda x: x.replace(year=x.year - 1))
+        g["prev_year_date"] = g["date"] - pd.DateOffset(years=1)
         
         # For each row, find the closest previous year value within tolerance
         prior_values = []

--- a/stitcher.py
+++ b/stitcher.py
@@ -583,11 +583,19 @@ class TrendsFetcher:
                 for dp in item.get("data", []):
                     date_str = dp.get("date_from") or dp.get("date")
                     ts = dp.get("timestamp")
+                    year = dp.get("year")
+                    month = dp.get("month")
                     date_val = None
-                    if date_str:
+                    if year is not None and month is not None:
+                        try:
+                            date_val = dt.date(int(year), int(month), 1)
+                        except Exception:
+                            date_val = None
+                    elif date_str:
                         date_val = pd.to_datetime(date_str).date()
                     elif ts:
                         date_val = pd.to_datetime(int(ts), unit="s").date()
+
                     values = dp.get("values")
                     if isinstance(values, list) and len(values) == len(kws):
                         for term, v in zip(kws, values):
@@ -869,9 +877,17 @@ class TrendsFetcher:
                                 if not isinstance(value, list):
                                     value = [value]  # Convert single value to array
 
+                                year = point.get("year")
+                                month = point.get("month")
+                                if year is not None and month is not None:
+                                    date_from = f"{int(year):04d}-{int(month):02d}-01"
+                                    timestamp = int(dt.datetime(int(year), int(month), 1).timestamp())
+                                else:
+                                    date_from = point.get("date_from", "")
+                                    timestamp = point.get("timestamp")
                                 timeline_point = {
-                                    "time": point.get("date_from", ""),
-                                    "timestamp": point.get("timestamp", 0),
+                                    "time": date_from,
+                                    "timestamp": timestamp,
                                     "value": value,
                                 }
                                 timeline_data.append(timeline_point)

--- a/tests/test_dataforseo_parse_year_month.py
+++ b/tests/test_dataforseo_parse_year_month.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import sys
+import datetime as dt
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from stitcher import TrendsFetcher
+
+
+def test_parse_dataforseo_year_month():
+    payload = {
+        "items": [
+            {
+                "type": "google_trends_graph",
+                "keywords": ["nike"],
+                "data": [
+                    {"year": 2023, "month": 1, "values": [10]},
+                    {"year": 2024, "month": 1, "values": [20]},
+                ],
+            }
+        ]
+    }
+    rows = TrendsFetcher._parse_dataforseo_trends(payload)
+    df = pd.DataFrame(rows)
+    assert df.shape[0] == 2
+    assert list(df["date"]) == [dt.date(2023, 1, 1), dt.date(2024, 1, 1)]
+    assert df["value"].tolist() == [10.0, 20.0]


### PR DESCRIPTION
## Summary
- parse DataForSEO responses containing separate `year` and `month`
- normalize DataForSEO payloads into proper timeline dates
- use DateOffset for prior-year lookup in YoY calculations
- add regression test for DataForSEO year/month parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7b6712924832d81254199e302c6c1