### PR TITLE
Aggregate weekly trend data to monthly averages for YoY calculations

### DIFF
--- a/app.py
+++ b/app.py
@@ -465,7 +465,9 @@ def infer_cadence(dates):
 def yoy_table(long_df: pd.DataFrame, term: str) -> pd.DataFrame:
     """
     Calculate year-over-year comparison for a given term.
-    Uses 365-day lag with nearest merge for weekly data, tolerance-based matching for others.
+    For weekly data, values are first averaged to monthly cadence before
+    computing the YoY difference. Monthly data is merged on year/month and
+    all other cadences use a tolerance-based nearest match.
     """
     # Filter data for the specific term and sort by date
     g = long_df[long_df["term"] == term].sort_values("date").copy()
@@ -488,34 +490,21 @@ def yoy_table(long_df: pd.DataFrame, term: str) -> pd.DataFrame:
     logger.debug(f"Detected data cadence: {cadence}")
     
     if cadence == "weekly":
-        # Use 365-day lag with nearest merge for weekly data
-        logger.debug("Using 365-day lag approach for weekly data")
-
-        # Create prior year data by shifting forward 365 days (1 year)
-        prior_data = g.copy()
-        prior_data["date"] = prior_data["date"] + pd.Timedelta(days=365)
-        prior_data = prior_data.rename(columns={"value": "prior_value"})
-        prior_data = prior_data[["date", "prior_value"]]
-
-        # Merge using merge_asof with tolerance
-        g = g.sort_values("date")
-        prior_data = prior_data.sort_values("date")
-
-        result = pd.merge_asof(
-            g,
-            prior_data,
-            on="date",
-            direction="nearest",
-            tolerance=pd.Timedelta(days=4)
-        )
-
-        logger.debug(f"365-day lag merge: {len(result)} rows, {result['prior_value'].notna().sum()} matches")
-
-    elif cadence == "monthly":
-        # Month/Year merge for monthly data
-        logger.debug("Using year/month merge for monthly data")
+        # Aggregate weekly points to monthly averages before YoY merge
+        logger.debug("Aggregating weekly data to monthly averages for YoY")
         g["year"] = g["date"].dt.year
         g["month"] = g["date"].dt.month
+        g = (
+            g.groupby(["year", "month"], as_index=False)["value"].mean()
+        )
+        g["date"] = pd.to_datetime(dict(year=g["year"], month=g["month"], day=1))
+        # After aggregation treat as monthly data
+
+    if cadence in {"weekly", "monthly"}:
+        logger.debug("Using year/month merge for monthly data")
+        if "year" not in g.columns:
+            g["year"] = g["date"].dt.year
+            g["month"] = g["date"].dt.month
 
         prior = g[["year", "month", "value"]].copy()
         prior["year"] = prior["year"] + 1

--- a/tests/test_yoy_weekly_to_monthly.py
+++ b/tests/test_yoy_weekly_to_monthly.py
@@ -1,0 +1,39 @@
+import ast
+from pathlib import Path
+import pandas as pd
+import numpy as np
+
+# Extract yoy_table and infer_cadence from app.py without importing streamlit
+app_path = Path(__file__).resolve().parents[1] / 'app.py'
+source = app_path.read_text()
+module = ast.parse(source)
+functions = {}
+for node in module.body:
+    if isinstance(node, ast.FunctionDef) and node.name in {'infer_cadence', 'yoy_table'}:
+        functions[node.name] = ast.get_source_segment(source, node)
+namespace = {'pd': pd, 'np': np}
+for name, src in functions.items():
+    exec(src, namespace)
+yoy_table = namespace['yoy_table']
+
+
+def test_yoy_weekly_aggregates_to_monthly():
+    rows = []
+    values = {2023: 100, 2024: 120, 2025: 180}
+    for year, val in values.items():
+        weeks = pd.date_range(f'{year}-01-01', f'{year}-01-31', freq='W-MON')
+        for d in weeks:
+            rows.append({'date': d.date(), 'term': 'nike', 'value': val})
+    df = pd.DataFrame(rows)
+    yt = yoy_table(df, 'nike')
+
+    assert yt.shape[0] == 3
+
+    r2024 = yt[yt['date'] == pd.Timestamp('2024-01-01')].iloc[0]
+    assert r2024['previous_year'] == 100
+    assert round(r2024['pct_diff'], 2) == 20.0
+
+    r2025 = yt[yt['date'] == pd.Timestamp('2025-01-01')].iloc[0]
+    assert r2025['previous_year'] == 120
+    assert round(r2025['pct_diff'], 2) == 50.0
+


### PR DESCRIPTION
## Summary
- Aggregate weekly trend data into monthly averages before computing year-over-year differences
- Merge monthly data by year and month and remove week-level YoY logic
- Add unit test ensuring weekly data collapses to single monthly YoY point

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7bf295324832d8525b55f7abf7f4a