### PR TITLE
Fix Bright Data request to avoid timeouts

### DIFF
--- a/stitcher.py
+++ b/stitcher.py
@@ -195,12 +195,14 @@ class TrendsFetcher:
                         "Accept": "application/json",
                     }
                     # Build Google Trends explore URL with Bright Data parsing flags
+                    # Request only the timeseries data (geo_map can slow down or timeout)
                     query_params = {
                         "q": ",".join(terms),
                         "hl": "en",
                         "date": self.timeframe if self.timeframe else "all",
                         "brd_json": "1",
-                        "brd_trends": "timeseries,geo_map",
+                        # Request only timeseries to match working cURL example and avoid timeouts
+                        "brd_trends": "timeseries",
                     }
                     if self.geo:
                         query_params["geo"] = self.geo
@@ -208,8 +210,8 @@ class TrendsFetcher:
                     payload = {
                         "zone": self.brightdata_zone or "YOUR_SERP_API_ZONE",
                         "url": trends_url,
-                        "method": "GET",
-                        "format": "json",
+                        # Use raw format to match working cURL example and reduce Bright Data processing
+                        "format": "raw",
                     }
                     request_endpoint = "https://api.brightdata.com/request"
                     logger.debug("Request endpoint: %s", request_endpoint)

--- a/tests/test_brightdata_payload.py
+++ b/tests/test_brightdata_payload.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from stitcher import TrendsFetcher
+
+
+class DummyResponse:
+    def __init__(self):
+        self.status_code = 200
+        self.headers = {}
+        self.text = ""
+        # mimic requests' elapsed attribute
+        class _Elapsed:
+            def total_seconds(self_inner):
+                return 0
+        self.elapsed = _Elapsed()
+
+    def json(self):
+        # minimal structure so _parse_timeseries succeeds
+        return {
+            "interest_over_time": {
+                "timeline_data": [
+                    {
+                        "time": "2024-01-01",
+                        "values": [
+                            {"query": "nike", "value": 1},
+                            {"query": "adidas", "value": 2},
+                        ],
+                    }
+                ]
+            }
+        }
+
+    def raise_for_status(self):
+        pass
+
+
+def test_brightdata_payload(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_post(url, *, json=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        return DummyResponse()
+
+    monkeypatch.setattr("stitcher.requests.post", fake_post)
+
+    fetcher = TrendsFetcher(
+        serpapi_key="dummy",
+        provider="brightdata",
+        cache_dir=str(tmp_path),
+        use_cache=False,
+        sleep_ms=0,
+        brightdata_zone="serp_api6",
+    )
+
+    fetcher.fetch_batch(["nike", "adidas"])
+
+    assert captured["url"] == "https://api.brightdata.com/request"
+    assert captured["json"]["format"] == "raw"
+    assert "brd_trends=timeseries" in captured["json"]["url"]
+    assert "geo_map" not in captured["json"]["url"]
+    assert captured["json"]["zone"] == "serp_api6"


### PR DESCRIPTION
## Summary
- Query Bright Data for only `timeseries` data to avoid extra processing that led to timeouts
- Use `raw` format for Bright Data requests to match working curl example
- Add regression test ensuring Bright Data payload uses `raw` format and only `timeseries`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7e6da8c6c832d9f4ea981c445e3a3