### PR TITLE
Fix Bright Data request to avoid timeouts

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,6 +42,7 @@ def setup_debug_logging():
     # Also suppress the specific Streamlit warning
     import logging
     logging.getLogger("streamlit.runtime.scriptrunner.script_runner").setLevel(logging.ERROR)
+    logging.getLogger("streamlit.runtime.scriptrunner.script_run_context").setLevel(logging.ERROR)
     logging.getLogger("streamlit.runtime.scriptrunner").setLevel(logging.ERROR)
     
     # Suppress urllib3 warnings that can also cause issues
@@ -165,17 +166,19 @@ def explore_autocomplete_options(terms: list, api_key: str):
 
 # If this script is executed with `python app.py` instead of
 # `streamlit run app.py`, re-launch it via the Streamlit CLI so the
-# interactive app works as expected.
-try:  # pragma: no cover - best effort safeguard
-    from streamlit.runtime.scriptrunner_utils import script_run_context
-    if script_run_context.get_script_run_ctx() is None:  # not running via `streamlit run`
-        import sys
-        from streamlit.web import cli as stcli
+# interactive app works as expected. Guard with __main__ so importing app
+# in tests doesn't trigger a Streamlit run.
+if __name__ == "__main__":  # pragma: no cover - import guard
+    try:
+        from streamlit.runtime.scriptrunner_utils import script_run_context
+        if script_run_context.get_script_run_ctx() is None:  # not running via `streamlit run`
+            import sys
+            from streamlit.web import cli as stcli
 
-        sys.argv = ["streamlit", "run", sys.argv[0]]
-        sys.exit(stcli.main())
-except Exception:
-    pass
+            sys.argv = ["streamlit", "run", sys.argv[0]]
+            sys.exit(stcli.main())
+    except Exception:
+        pass
 
 # Initialize session state
 if 'data_loaded' not in st.session_state:

--- a/brightdata_smoke.py
+++ b/brightdata_smoke.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Simple Bright Data smoke test.
+
+This script replicates the Bright Data Google Trends request used by the
+application. Provide keywords and optional zone/timeframe/geo arguments.
+The Bright Data API token is read from the ``BRIGHTDATA_TOKEN`` environment
+variable by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from urllib.parse import urlencode
+
+import requests
+
+BRIGHTDATA_ENDPOINT = "https://api.brightdata.com/request"
+
+
+def build_trends_url(keywords: list[str], *, timeframe: str, geo: str | None) -> str:
+    """Create the Google Trends explore URL Bright Data expects."""
+    params = {
+        "q": ",".join(keywords),
+        "hl": "en",
+        "date": timeframe,
+        "brd_json": "1",
+        # Request only timeseries data to avoid heavy parsing
+        "brd_trends": "timeseries",
+    }
+    if geo:
+        params["geo"] = geo
+    return f"https://trends.google.com/trends/explore?{urlencode(params)}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run a Bright Data smoke test")
+    parser.add_argument("keywords", nargs="+", help="Keywords to query")
+    parser.add_argument("--zone", default="serp_api6", help="Bright Data SERP zone")
+    parser.add_argument("--timeframe", default="today 5-y", help="Google Trends timeframe")
+    parser.add_argument("--geo", default="", help="Google Trends geo code")
+    parser.add_argument("--token", default=os.getenv("BRIGHTDATA_TOKEN"), help="Bright Data API token")
+    args = parser.parse_args()
+
+    if not args.token:
+        parser.error("Bright Data token not provided. Set BRIGHTDATA_TOKEN or use --token")
+
+    url = build_trends_url(args.keywords, timeframe=args.timeframe, geo=args.geo)
+    payload = {"zone": args.zone, "url": url, "format": "raw"}
+    headers = {
+        "Authorization": f"Bearer {args.token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    start = time.time()
+    try:
+        resp = requests.post(BRIGHTDATA_ENDPOINT, json=payload, headers=headers, timeout=180)
+    except Exception as exc:  # pragma: no cover - network errors
+        print(f"Request failed: {exc}")
+        return 1
+    elapsed = time.time() - start
+    print(f"Status: {resp.status_code} in {elapsed:.1f}s")
+    print(resp.text[:500])
+    return 0 if resp.ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    sys.exit(main())

--- a/tests/test_brightdata_payload.py
+++ b/tests/test_brightdata_payload.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from stitcher import TrendsFetcher
+
+
+class DummyResponse:
+    def __init__(self):
+        self.status_code = 200
+        self.headers = {}
+        self.text = ""
+        # mimic requests' elapsed attribute
+        class _Elapsed:
+            def total_seconds(self_inner):
+                return 0
+        self.elapsed = _Elapsed()
+
+    def json(self):
+        # minimal structure so _parse_timeseries succeeds
+        return {
+            "interest_over_time": {
+                "timeline_data": [
+                    {
+                        "time": "2024-01-01",
+                        "values": [
+                            {"query": "nike", "value": 1},
+                            {"query": "adidas", "value": 2},
+                        ],
+                    }
+                ]
+            }
+        }
+
+    def raise_for_status(self):
+        pass
+
+
+def test_brightdata_payload(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_post(url, *, json=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return DummyResponse()
+
+    monkeypatch.setattr("stitcher.requests.post", fake_post)
+
+    fetcher = TrendsFetcher(
+        serpapi_key="dummy",
+        provider="brightdata",
+        cache_dir=str(tmp_path),
+        use_cache=False,
+        sleep_ms=0,
+        brightdata_zone="serp_api6",
+    )
+
+    fetcher.fetch_batch(["nike", "adidas"])
+
+    assert captured["url"] == "https://api.brightdata.com/request"
+    assert captured["json"]["format"] == "raw"
+    assert "brd_trends=timeseries" in captured["json"]["url"]
+    assert "geo_map" not in captured["json"]["url"]
+    assert captured["json"]["zone"] == "serp_api6"
+    assert captured["timeout"] == 180

--- a/tests/test_streamlit_warning_suppression.py
+++ b/tests/test_streamlit_warning_suppression.py
@@ -1,0 +1,7 @@
+from app import setup_debug_logging
+import logging
+
+def test_script_run_context_warning_suppressed():
+    setup_debug_logging()
+    logger = logging.getLogger("streamlit.runtime.scriptrunner.script_run_context")
+    assert logger.getEffectiveLevel() == logging.ERROR


### PR DESCRIPTION
## Summary
- Query Bright Data for only `timeseries` data to avoid extra processing that led to timeouts
- Use `raw` format for Bright Data requests to match working curl example
- Expand Bright Data request timeout to 180 seconds to better handle slow responses
- Add regression test ensuring Bright Data payload uses `raw` format, only `timeseries`, and passes expanded timeout
- Silence "missing ScriptRunContext" warnings in Streamlit and guard CLI relaunch so imports don't spawn Streamlit
- Add test verifying Streamlit warning suppression
- Provide a standalone `brightdata_smoke.py` script for manual Bright Data API smoke testing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7e6da8c6c832d9f4ea981c445e3a3